### PR TITLE
Buggy url resolve

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -58,7 +58,7 @@ Crawler.prototype.getAllUrls = function(baseUrl, body) {
     var match = /href=\"(.*?)[#\"]/.exec(link);
 
     link = match[1];
-    link = link = url.resolve(baseUrl, link);
+    link = url.resolve(baseUrl, link);
     return link;
   });
   return _.chain(links)

--- a/crawler.js
+++ b/crawler.js
@@ -1,5 +1,6 @@
 var request = require("request");
 var _ = require("underscore");
+var url = require('url');
 
 var DEFAULT_DEPTH = 2;
 
@@ -57,7 +58,7 @@ Crawler.prototype.getAllUrls = function(baseUrl, body) {
     var match = /href=\"(.*?)[#\"]/.exec(link);
 
     link = match[1];
-    link = link.indexOf("://") >=0 ? link : baseUrl + link;
+    link = link = url.resolve(baseUrl, link);
     return link;
   });
   return _.chain(links)


### PR DESCRIPTION
Example if baseUrl is http://www.syr.edu/facultyandstaff/index.html and
anchor url is ../admissions/index.html, then it was trying to fetch
http://www.syr.edu/facultyandstaff/index.html../admissions/index.html
which is wrong.

Fixed with node builtin function url.resolve(from, to), Ref:
https://nodejs.org/docs/latest/api/url.html

Solution:
at line 3: var url = require('url');
at line 61: link = url.resolve(baseUrl, link);