### PR TITLE
Adding ability to pass custom user agent to crawler requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The default value is `2`.
 
 The default value is `false`.
 
+* `userAgent` - User agent to send with crawler requests.
+
+The default value is `crawler/js-crawler`
+
 * `shouldCrawl` - function that specifies whether an url should be crawled, returns `true` or `false`.
 
 Example:

--- a/crawler.js
+++ b/crawler.js
@@ -3,11 +3,13 @@ var _ = require("underscore");
 var url = require('url');
 
 var DEFAULT_DEPTH = 2;
+var DEFAULT_USERAGENT = 'crawler/js-crawler';
 
 function Crawler() {
   this.crawledUrls = {};
   this.depth = DEFAULT_DEPTH;
   this.ignoreRelative = false;
+  this.userAgent = DEFAULT_USERAGENT;
   this._beingCrawled = [];
   this.shouldCrawl = function() {
     return true;
@@ -18,6 +20,7 @@ Crawler.prototype.configure = function(options) {
   this.depth = (options && options.depth) || this.depth;
   this.depth = Math.max(this.depth, 0);
   this.ignoreRelative = (options && options.ignoreRelative) || this.ignoreRelative;
+  this.userAgent = (options && options.userAgent) || this.userAgent;
   this.shouldCrawl = (options && options.shouldCrawl) || this.shouldCrawl;
   return this;
 };
@@ -58,7 +61,12 @@ Crawler.prototype._crawlUrl = function(url, depth, onSuccess, onFailure, onAllFi
   var self = this;
 
   this._startedCrawling(url);
-  request(url, function(error, response, body) {
+  request({
+    url : url,
+    headers: {
+      'User-Agent' : this.userAgent
+    }
+  }, function(error, response, body) {
     self.crawledUrls[url] = true;
     if (!error && response.statusCode == 200) {
       onSuccess({


### PR DESCRIPTION
Addresses issue #5. Added option to configure() to pass a user agent to crawler requests. I am not sure if the default I set is appropriate though, I will look at other options as well and update branch if I find a better solution for that.