### PR TITLE
mark-up matching is now case-insensitive

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -151,11 +151,11 @@ Crawler.prototype._crawlUrl = function(url, depth, onSuccess, onFailure, onAllFi
 
 Crawler.prototype._getAllUrls = function(baseUrl, body) {
   var self = this;
-  var linksRegex = self.ignoreRelative ? /<a[^>]+?href=".*?:\/\/.*?"/gm : /<a[^>]+?href=".*?"/gm;
+  var linksRegex = self.ignoreRelative ? /<a[^>]+?href=".*?:\/\/.*?"/gmi : /<a[^>]+?href=".*?"/gmi;
   var links = body.match(linksRegex) || [];
 
   links = _.map(links, function(link) {
-    var match = /href=\"(.*?)[#\"]/.exec(link);
+    var match = /href=\"(.*?)[#\"]/i.exec(link);
 
     link = match[1];
     link = url.resolve(baseUrl, link);


### PR DESCRIPTION
Hi,

I had problems using js-crawler because a & href regexps are case-sensitive and shouldn't.

Source: http://www.w3.org/TR/html-markup/documents.html#case-insensitivity

Regards,