### PR TITLE
Fixed undefined reference to onAllFinished callback in _requestUrl

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -155,7 +155,7 @@ Crawler.prototype._requestUrl = function(options, callback) {
     var willSkip = _.contains(self.knownUrls, url) || !self.shouldCrawl(url);
 
     if (willSkip && _.contains(self._currentUrlsToCrawl, url)) {
-      self._finishedCrawling(url, onAllFinished);
+      self._finishedCrawling(url, callback);
     }
     return willSkip;
   });


### PR DESCRIPTION
I found an undefined reference to the `onAllFinished` callback within `_requestUrl`.

In the `shouldSkip` callback of `workExecutor.submit`, if the url should be skipped then `_finishedCrawling` is passed `onAllFinished`, which does not exist in this context. 

Passed `callback` to `_finishedCrawling` instead.