### PR TITLE
Minor changes were made to handle binary resources

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -1,4 +1,4 @@
-﻿var request = require('request');
+var request = require('request');
 var _ = require('underscore');
 var url = require('url');
 

--- a/crawler.js
+++ b/crawler.js
@@ -1,4 +1,4 @@
-var request = require('request');
+﻿var request = require('request');
 var _ = require('underscore');
 var url = require('url');
 


### PR DESCRIPTION
By default, **_request_** treats all responded data as utf-8 encoded strings which will come out incorrect stringified body for binary resource, in this patch some changes were made to address this issue by:
1. Add _encoding: null_ option prior to request any resource, thereby the responded body will provided as a node.js Buffer;
2. To make link analysis work, stringify responded body with either utf-8 or designed encoding before call the analyzer function.