### PR TITLE
A small change to omit comments in html body

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -233,6 +233,7 @@ Crawler.prototype._crawlUrl = function(url, referer, depth) {
 
 Crawler.prototype._getAllUrls = function(baseUrl, body) {
   var self = this;
+  body = body.replace(/<!--.*?-->/g, '');  // Added by @tibetty to omit commented contents which might mislead following link-parsing
   var linksRegex = self.ignoreRelative ? /<a[^>]+?href=".*?:\/\/.*?"/gmi : /<a[^>]+?href=".*?"/gmi;
   var links = body.match(linksRegex) || [];
 


### PR DESCRIPTION
Reason: comments might mislead following link parsing
In function: Crawler.prototype._getAllUrls = function(baseUrl, body)
body = body.replace(/<!--.*?-->/g, '');  // Added by @tibetty to omit commented contents which might mislead following link-parsing