### PR TITLE
Fix a tiny but disastrous bug to make depth works as it should be

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -213,7 +213,8 @@ Crawler.prototype._crawlUrl = function(url, referer, depth) {
           var encoding = 'utf8';
           if (response.headers['content-encoding']) encoding = response.headers['content-encoding'];
           var encodedBody = body.toString(encoding);
-          self._crawlUrls(self._getAllUrls(lastUrlInRedirectChain, encodedBody), depth - 1);
+          // dear @antivanov, see this null parameters newly added by me? It's an old bug in the original version - @tibetty
+          self._crawlUrls(self._getAllUrls(lastUrlInRedirectChain, encodedBody), null, depth - 1);
         }
       }
     } else if (self.onFailure) {


### PR DESCRIPTION
In old code, without this "null --> referrer" parameter, the depth - 1 passed in is treated as referrer, while depth parameter in _crawlUrl method becomes 'undefined', and eventually it makes the depth related control totally malfunctions.  I correct this bug by simply adding null. LMAO!