### PR TITLE
Add referer directly to page object, support for single quote hrefs

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -306,13 +306,13 @@ Crawler.prototype._getAllUrls = function(defaultBaseUrl, body) {
   var self = this;
   body = this._stripComments(body);
   var baseUrl = this._getBaseUrl(defaultBaseUrl, body);
-  var linksRegex = self.ignoreRelative ? /<a[^>]+?href=".*?:\/\/.*?"/gmi : /<a[^>]+?href=".*?"/gmi;
+  var linksRegex = self.ignoreRelative ? /<a[^>]+?href=["'].*?:\/\/.*?["']/gmi : /<a[^>]+?href=["'].*?["']/gmi;
   var links = body.match(linksRegex) || [];
 
   //console.log('body = ', body);
   var urls = _.chain(links)
     .map(function(link) {
-      var match = /href=\"(.*?)[#\"]/i.exec(link);
+      var match = /href=[\"\'](.*?)[#\"\']/i.exec(link);
 
       link = match[1];
       link = url.resolve(baseUrl, link);

--- a/crawler.js
+++ b/crawler.js
@@ -232,7 +232,8 @@ Crawler.prototype._crawlUrl = function(url, referer, depth) {
           content: body,
           error: error,
           response: response,
-          body: body
+          body: body,
+          referer: referer || ""
         });
         self.knownUrls[lastUrlInRedirectChain] = true;
         self.crawledUrls.push(lastUrlInRedirectChain);
@@ -247,7 +248,8 @@ Crawler.prototype._crawlUrl = function(url, referer, depth) {
         content: body,
         error: error,
         response: response,
-        body: body
+        body: body,
+        referer: referer || ""
       });
       self.crawledUrls.push(url);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-crawler",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Web crawler for Node.js",
   "main": "crawler.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-crawler",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Web crawler for Node.js",
   "main": "crawler.js",
   "directories": {

--- a/spec/crawler.spec.js
+++ b/spec/crawler.spec.js
@@ -76,6 +76,11 @@ Link c\
       expect(crawler._getAllUrls(baseUrl, '<a href="ftp://myserver.org"></a>'))
         .toEqual([]);
     });
+    
+    it('should work with single or double quoted attribute values', function() {
+      expect(crawler._getAllUrls(baseUrl, '<a href="http://doublequoted.org"></a>'+"<a href='http://singlequoted.org'></a>"))
+        .toEqual(['http://doublequoted.org/','http://singlequoted.org/']);
+    });
 
     describe('ignoreRelative option', function() {
 


### PR DESCRIPTION
Adding referer to page object sent to callbacks, as an easy/accessible method to understand how the crawler got to the current page. Also, adding single quotes to href, as per [this fork.](https://github.com/langfordguy82/js-crawler) (including unit tests)

Reason: the crawler now lends itself to testing for dead-links (pages that have link-outs to 404s and 500s).

Reference Issue: https://github.com/antivanov/js-crawler/issues/35