### PR TITLE
Added shouldSpider to supplement shouldCrawl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -177,14 +177,22 @@ The default value is `false`.
 
 The default value is `crawler/js-crawler`
 
-* `shouldCrawl` - function that specifies whether an url should be crawled, returns `true` or `false`.
-
 * `maxRequestsPerSecond` - the maximum number of HTTP requests per second that can be made by the crawler, default value is 100
 
 * `maxConcurrentRequests` - the maximum number of concurrent requests that should not be exceeded by the crawler, the default value is 10
 
-Example:
+* `shouldCrawl` - function that specifies whether a url should be crawled/requested, returns `true` or `false`.
 
+* `shouldSpider` - function that specifies whether the spider should crawl a URL for additional links, returns `true` or `false`.
+
+Note: `shouldCrawl` determines if a given URL should be requested/visited at all, where as `shouldSpider` determines if the links on a given URL should be harvested/added to the crawling queue. 
+Many users may find that setting `shouldCrawl` is sufficient, as URLs cannot be spidered if they are never visited/requested.
+A common use case for having these functions separated: if a user would like to check external links on a site for errors, without crawling those external links, the user could create a `shouldSpider` function that restricts spidering to the original URL.
+
+
+**Examples:**
+
+The following will crawl the specified URL, but not allow external URLs to be visited/requested, and therefore not search for additional links to crawl on the external URLs:
 ```javascript
 var Crawler = require("js-crawler");
 
@@ -199,7 +207,22 @@ crawler.crawl("http://www.reddit.com/r/javascript", function(page) {
 });
 ```
 
-Default value is a function that always returns `true`.
+The following will crawl the specified URL, allow external URLs to be visited/requested, but will not search for additional links to crawl on the external URLs:
+```javascript
+var Crawler = require("js-crawler");
+
+var crawler = new Crawler().configure({
+  shouldSpider: function(url) {
+    return url.indexOf("reddit.com") < 0;
+  }
+});
+
+crawler.crawl("http://www.reddit.com/r/javascript", function(page) {
+  console.log(page.url);
+});
+```
+
+The default value for each is a function that always returns `true`.
 
 #### Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-crawler",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Web crawler for Node.js",
   "main": "crawler.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-crawler",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Web crawler for Node.js",
   "main": "crawler.js",
   "directories": {


### PR DESCRIPTION
This is a redo of PR: https://github.com/antivanov/js-crawler/pull/38, as I was having issues rebasing my branch effectively.

I added a function named shouldSpider to the options, to supplement the shouldCrawl function.

The purpose of shouldCrawl, as the function name describes, is to determine if the crawler should crawl/visit/request a specific page. This allows users to only crawl specific sites, or perform other validation on the URL before the page is even requested.

The shouldSpider function allows users to further expand upon the decision making capabilities of shouldCrawl. Previously, after requesting a page successfully, shouldCrawl is called again to determine if the page should be spidered for additional links to crawl. Now, shouldSpider is called instead of an additional call to shouldCrawl. Users can therefore allow pages to be requested/visited, but restrict those pages from collecting additional links to crawl.

A common use case would be crawling your own domain for dead links, finding all the links that go to 404 and 500 pages, including external pages. A user can use shouldSpider instead of shouldCrawl, allowing external pages to be requested/visited but stopping the crawler from collecting the links on the external page.

Note that this PR is backwards compatible, so existing implementations should still work. I have also added the new function to the readme, including a use case and example.