### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "examples"
   ],
   "dependencies": {
-    "request": "~2.55.0",
+    "request": "~2.87.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
There are some vulnerabilities according to `npm audit` and a deprecated `node-uuid` dependency.

I tested this with my package [@crstn/request](https://www.npmjs.com/package/@crstn/redirect). The crawling works like before and all warnings (vulnerabilities and deprecated) are gone.

Needs further reviewing for other use cases.

Closes crstnio/redirect#1.